### PR TITLE
Set up park provider to use nps api for getting data

### DIFF
--- a/scripts/parks/ParkProvider.js
+++ b/scripts/parks/ParkProvider.js
@@ -1,0 +1,13 @@
+import { settings } from '../Settings.js';
+
+let parks = [];
+
+export const useParks = () => {
+  return parks.slice();
+}
+
+export const getParks = () => {
+  return fetch(`https://developer.nps.gov/api/v1/parks?api_key=${settings.npsKey}`)
+  .then(res => res.json())
+  .then(res => parks = res.data);
+}


### PR DESCRIPTION
- Created a data provider for National Park Service data that gets parks
- The data provider fetches a basic query of all parks with a limit of 50 
- You can see the change in vscode but will require some calls to actually see the data